### PR TITLE
Don't use \str_replace to retrieve entity name from proxy

### DIFF
--- a/Model/Entity.php
+++ b/Model/Entity.php
@@ -6,6 +6,8 @@
 
 namespace SmartTeam\DoctrineBehaviors\Model;
 
+use Doctrine\ORM\Proxy\Proxy;
+
 /**
  * Trait Entity
  *
@@ -13,18 +15,14 @@ namespace SmartTeam\DoctrineBehaviors\Model;
  */
 trait Entity
 {
-    /**
-     * @param $entity
-     *
-     * @return string
-     */
     public static function getClass($entity): string
     {
-        if (is_object($entity)) {
-            $class = get_class($entity);
-        } else {
-            $class = $entity;
+        $class = \is_string($entity) ? $entity : \get_class($entity);
+        $reflection = new \ReflectionClass($class);
+        if ($reflection->implementsInterface(Proxy::class)) {
+            $class = $reflection->getParentClass()->getName();
         }
-        return str_replace('Proxies\\__CG__\\', '', $class);
+
+        return $class;
     }
 }


### PR DESCRIPTION
namespace for doctrine proxies is configurable and there's no guarantee that it is `Proxies`, we should use ReflectionClass instead to check if the class is a proxy, by checking whether or not it implements `Doctrine\ORM\Proxy\Proxy`